### PR TITLE
feat(workflow): add fork-sync workflow

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -9,9 +9,14 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: tgymnich/fork-sync@v2
         with:
           head: main # form 元リポジトリのブランチ
           base: main # fork 先リポジトリ (== ワークフローが動作するリポジトリ) の PR マージ対象ブランチ
+          token: ${{ secrets.GITHUB_TOKEN }}
           auto_approve: false # 自動 Approve しない
           auto_merge: false # 自動 merge しない

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -1,0 +1,17 @@
+name: Fork Sync
+
+on:
+  schedule:
+    - cron: '0 12 * * *' # 毎日 12:00pm
+  workflow_dispatch: # 手作業での実行も可
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tgymnich/fork-sync@v2
+        with:
+          head: main # form 元リポジトリのブランチ
+          base: main # fork 先リポジトリ (== ワークフローが動作するリポジトリ) の PR マージ対象ブランチ
+          auto_approve: false # 自動 Approve しない
+          auto_merge: false # 自動 merge しない


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - フォーク元リポジトリのmainブランチとフォーク先リポジトリのmainブランチを自動で同期するGitHub Actionsワークフローを追加しました。ワークフローは毎日12:00に実行され、手動でも実行できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->